### PR TITLE
remove case ordering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,13 +477,6 @@ for {
 }
 ```
 
-## Case Ordering
-
-As a general practice, the ordering of case statements should be prioritized from most likely to be the executed to least likely.
-For example, if you expect a `Try` to generally succeed, the first case in the match should be `Success(s)`, followed by `Failure(f)`.
-
-The same goes for if/else statements, naturally.
-
 # Akka
 
 ## Ask and Tell


### PR DESCRIPTION
Ordering cases by having the simplest thing be first is common practice in functional programming. I see two reasons to do so:
1. Tail recursion 
2. Understanding the base case makes it easier to read the more complicated case.

On the other hand, I understand the desire to have Failure cases be at the bottom, so it looks more like a try/catch block.

To avoid coming up with complicated rules I suggest removing this clause altogether.